### PR TITLE
Fixed up CSS/JS assets reference typo in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ And then execute:
 
 In `application.js`:
 
-    //= require bootstrap-multiselect-rails
+    //= require bootstrap-multiselect
 
 In `application.css`:
 
-    *= require bootstrap-multiselect-rails
+    *= require bootstrap-multiselect
 
 ## License
 


### PR DESCRIPTION
Docs need to be updated to correctly reflect how to include the CSS/JS assets in a Rails app.
